### PR TITLE
add allowTokensAfterEndif setting for pragma ignore

### DIFF
--- a/Header.pas
+++ b/Header.pas
@@ -863,7 +863,8 @@ procedure EndInclude {chPtr: ptr};
                   p_ignore:
                      WriteByte(ord(skipIllegalTokens)
                         | (ord(allowLongIntChar) << 1)
-                        | (ord(slashSlashComments) << 3));
+                        | (ord(allowTokensAfterEndif) << 2)
+                        | (ord(allowSlashSlashComments) << 3));
 
                   p_segment: begin
                      for i := 1 to 10 do begin
@@ -1496,7 +1497,8 @@ var
             i := ReadByte;
             skipIllegalTokens := odd(i);
             allowLongIntChar := odd(i >> 1);
-            slashSlashComments := odd(i >> 3);
+            allowTokensAfterEndif := odd(i >> 2);
+            allowSlashSlashComments := odd(i >> 3);
             end;
          
          p_segment: begin

--- a/Scanner.asm
+++ b/Scanner.asm
@@ -329,7 +329,7 @@ lb9      anop
 !    {characters and return a space.      }
 !    if (not doingstring) and (ch = '/') and (chPtr <> eofPtr)
 !       and ((chr(chPtr^) = '*')
-!       or ((chr(chPtr^) = '/') and slashSlashComments))then begin
+!       or ((chr(chPtr^) = '/') and allowSlashSlashComments))then begin
          lda   doingstring
          jne   lc6
          lda   ch
@@ -348,7 +348,7 @@ lc1      move4 chPtr,p1
 	beq	lc1a
 	cmp	#'/'
          jne   lc6
-	ldx	slashSlashComments
+	ldx	allowSlashSlashComments
 	jeq	lc6
 !       cch := chr(chPtr^);
 lc1a	sta	cch

--- a/Scanner.pas
+++ b/Scanner.pas
@@ -77,10 +77,14 @@ var
    pathList: pathRecordPtr;		{additional search paths}
    printMacroExpansions: boolean;       {print the token list?}
    reportEOL: boolean;                  {report eolsy as a token?}
-   skipIllegalTokens: boolean;		{skip flagging illegal tokens in skipped code?}
-   slashSlashComments: boolean;		{allow // comments?}
-   allowLongIntChar: boolean;		{allow long int char constants?}
    token: tokenType;                    {next token to process}
+
+                                        {#pragma ignore flags}
+                                        {--------------------}
+   allowLongIntChar: boolean;           {allow long int char constants?}
+   allowSlashSlashComments: boolean;    {allow // comments?}
+   allowTokensAfterEndif: boolean;      {allow tokens after #endif?}
+   skipIllegalTokens: boolean;          {skip flagging illegal tokens in skipped code?}
 
 {---------------------------------------------------------------}
 
@@ -2226,9 +2230,6 @@ var
       ip: ifPtr;                        {used to create a new if record}
  
    begin {DoEndif}
-   NextToken;                           {skip the command name}
-   if token.kind <> eolsy then          {check for extra stuff on the line}
-      Error(11);
    if ifList <> nil then begin
       ip := ifList;                     {remove the top if record from the list}
       ifList := ip^.next;
@@ -2240,6 +2241,10 @@ var
       end {if}
    else
       Error(20);
+   NextToken;                           {skip the command name}
+   if token.kind <> eolsy then          {check for extra stuff on the line}
+      if not allowTokensAfterEndif then
+         Error(11);
    end; {DoEndif}
 
 
@@ -2767,13 +2772,16 @@ if ch in ['a','d','e','i','l','p','u','w'] then begin
                   else if token.name^ = 'ignore' then begin
                      { ignore bits:                                        }
                      {     1 - don't flag illegal tokens in skipped source }
+                     {     2 - allow long int character constants          }
+                     {     4 - allow tokens after #endif                   }
                      {     8 - allow // comments                           }
                      FlagPragmas(p_ignore);
                      NumericDirective;    
                      val := long(expressionValue).lsw;
                      skipIllegalTokens := odd(val);
                      allowLongIntChar := odd(val >> 1);
-                     slashSlashComments := odd(val >> 3);
+                     allowTokensAfterEndif := odd(val >> 2);
+                     allowSlashSlashComments := odd(val >> 3);
                      if token.kind <> eolsy then
                         Error(11);
                      end {else if}
@@ -3344,7 +3352,8 @@ begin {InitScanner}
 printMacroExpansions := false;          {don't print the token list}
 skipIllegalTokens := false;		{flag illegal tokens in skipped code}
 allowLongIntChar := false;		{allow long int char constants}
-slashSlashComments := true;		{allow // comments}
+allowTokensAfterEndif := false;         {allow tokens after #endif}
+allowSlashSlashComments := true;		{allow // comments}
 foundFunction := false;                 {no functions found so far}
 fileList := nil;                        {no included files}
 gettingFileName := false;               {not in GetFileName}


### PR DESCRIPTION
#pragma ignore bit 3 ignores extra tokens after #endif. Default is off so there is it requires opting-in to take effect.

(Taken from MPW Orca/C IIgs, updates the source and slashSlashComments variable to match MPW version)