### PR TITLE
generate function exit cop with profiling / #pragma debug 4.

### DIFF
--- a/Gen.pas
+++ b/Gen.pas
@@ -5061,8 +5061,8 @@ procedure GenTree {op: icptr};
    if namePushed then
       GenCall(2);
 
-   {generate an exit code for the debugger's benefit}
-   if debugFlag then
+   {generate an exit code for the debugger/profiler's benefit}
+   if debugFlag or profileFlag then
       GenNative(m_cop, immediate, 4, nil, 0);
 
    {if anything needs to be removed from the stack, move the return val}


### PR DESCRIPTION
I verified in the prizm source code that profiling expects a COP 3 for function entry and a COP 4 for function exit.  Currently, profiling doesn't generate the COP 5 for function exit.