### PR TITLE
Fix debugger symbol tables with forward declared structs

### DIFF
--- a/Symbol.pas
+++ b/Symbol.pas
@@ -982,6 +982,9 @@ var
 
       begin {ExpandStructType}
       ip := tp^.fieldList;
+      { fieldList is nil if this is a forward declared struct. }
+      if ip = nil then ip := defaultStruct^.fieldList;
+
       while ip <> nil do begin
          GenSymbol(ip, none);
          ip := ip^.next;


### PR DESCRIPTION
Forward-declared structs have no field list and generate an invalid debugger symbol table.  Generate a valid struct entry by re-using the default error struct ({ field: int })

```
int bleh(struct xxx *parm) {
  return 0;
}
```
Before:
```
000089 000016 |          DC    I'24'
00008C 000018 |          DC    I4'((bleh+$0000004E)+$00000014)'  ; 'parm'
00009A 00001C |          DC    I4'8'
00009E 000020 |          DC    H'00 0B'  ; pointer
0000A0 000022 |          DC    I2'0'
0000A2 000024 |          DC    I4'0'
0000A6 000028 |          DC    I4'0'
0000AA 00002C |          DC    H'00 0C'  ; to a struct
0000AC 00002E |          DC    I2'0'
; no field list
```

After:

```
000089 000016 |          DC    I'36'
00008C 000018 |          DC    I4'((bleh+$0000005A)+$00000014)'  ; 'parm'
00009A 00001C |          DC    I4'8'
00009E 000020 |          DC    H'00 0B'  ; pointer
0000A0 000022 |          DC    I2'0'
0000A2 000024 |          DC    I4'0'
0000A6 000028 |          DC    I4'0'
0000AA 00002C |          DC    H'00 0C'  ; to a struct
0000AC 00002E |          DC    I2'0'
; field list
0000AF 000030 |          DC    I4'((bleh+$0000005A)+$00000019)' l 'field'
0000BD 000034 |          DC    I4'0'  ; offset
0000C1 000038 |          DC    H'00 01'  ; last field, type int
0000C3 00003A |          DC    I2'0'
```