### PR TITLE
more nested struct type tweaks

### DIFF
--- a/Symbol.pas
+++ b/Symbol.pas
@@ -836,7 +836,7 @@ var
       tp1^.next := tpList;
       tpList := tp1;
       tp1^.tp := tp;
-      tp1^.disp := symLength;
+      tp1^.disp := symLength-12;
       end; {else}
    end; {GetTypeDisp}
 
@@ -848,8 +848,6 @@ var
    { parameters:						}
    {    ip - identifier to generate				}
    {    storage - storage type; none for struct/union fields	}
-
-   label 1;
 
    var
       disp: integer;			{disp to symbol of same type}
@@ -1094,6 +1092,7 @@ var
    if ip^.itype^.kind in
       [scalarType,arrayType,pointerType,enumType,structType,unionType]
       then begin
+      symLength := symLength+12;        {update length of symbol table}
       WriteName(ip);			{write the name field}
       WriteAddress(ip);			{write the address field}
       case ip^.itype^.kind of
@@ -1110,11 +1109,7 @@ var
                         if disp = noDisp then begin
         		   CnOut(12);
         		   CnOut2(0);
-                           		{update length of symbol table before  }
-                           		{handling any nested struct definitions}
-                           symLength := symLength+12;
                            ExpandStructType(ip^.itype);
-                           goto 1;
                            end {if}
                         else begin
         		   CnOut(13);
@@ -1122,8 +1117,7 @@ var
                            end; {else}
                         end;
          end; {case}
-      symLength := symLength+12;	{update length of symbol table}
-1:    end; {if}
+      end; {if}
    end; {GenSymbol}
 
 


### PR DESCRIPTION
Previous embedded struct debugger fix didn't account for pointers to structs (ExpandPointerType).

This always pre-increments symLength then compensate by subtracting 12 in GetTypeDisp.

```
struct point { int x; int y; };
struct rect { struct point topLeft; struct point bottomRight; };

int yyy(void) {
  struct rect *rr;
  return 0;
}
```

before:
```
000084 000014 |          COP   $05
000088 000016 |          DC    I'72'
00008B 000018 |          DC    I4'((yyy+$00000076)+$0000000E)'
000099 00001C |          DC    I4'5'
00009D 000020 |          DC    H'00 0B' ; pointer to
00009F 000022 |          DC    I2'0'
0000A1 000024 |          DC    I4'0'
0000A5 000028 |          DC    I4'0'
0000A9 00002C |          DC    H'00 0C' ; struct rect
0000AB 00002E |          DC    I2'0'
0000AE 000030 |          DC    I4'((yyy+$00000076)+$00000011)' topLeft
0000BC 000034 |          DC    I4'0'
0000C0 000038 |          DC    H'01 0C' ;struct point
0000C2 00003A |          DC    I2'0'
0000C5 00003C |          DC    I4'((yyy+$00000076)+$00000019)' ; x
0000D3 000040 |          DC    I4'0'
0000D7 000044 |          DC    H'01 01'
0000D9 000046 |          DC    I2'0'
0000DC 000048 |          DC    I4'((yyy+$00000076)+$0000001B)' ; y
0000EA 00004C |          DC    I4'2'
0000EE 000050 |          DC    H'00 01'
0000F0 000052 |          DC    I2'0'
0000F3 000054 |          DC    I4'((yyy+$00000076)+$0000001D)' ; bottomRight
000101 000058 |          DC    I4'4'
000105 00005C |          DC    H'00 0D'
000107 00005E |          DC    I2'12' ; offset to $24, struct rect 
```
after
```
...
0000F3 000054 |          DC    I4'((yyy+$00000076)+$0000001D)' ; bottomRight
000101 000058 |          DC    I4'4'
000105 00005C |          DC    H'00 0D'
000107 00005E |          DC    I2'24'  ; offset to $30, struct point
```
