### PR TITLE
floating point constant division by 0.0

### DIFF
--- a/Expression.pas
+++ b/Expression.pas
@@ -1199,13 +1199,8 @@ var
                   plusch      : rop1 := rop1 + rop2;                    {+}
                   minusch     : rop1 := rop1 - rop2;                    {-}
                   asteriskch  : rop1 := rop1 * rop2;                    {*}
-                  slashch     : begin                                   {/}
-                                if rop2 = 0.0 then begin
-                                   Error(109);
-                                   rop2 := 1.0;
-                                   end; {if}
-                                rop1 := rop1 / rop2;
-                                end;
+                  slashch     : rop1 := rop1 / rop2;                    {/}
+
                   otherwise   : Error(66);              {illegal operation}
                   end; {case}
                if ekind = intconst then begin


### PR DESCRIPTION
Floating point division by 0.0 is well defined and occasionally used to generate +/- infinity values. I don't think it's necessary or standard compliant to treat it as an error.