### PR TITLE
#define should always use the global memory pool

### DIFF
--- a/Scanner.pas
+++ b/Scanner.pas
@@ -2786,8 +2786,12 @@ var
       ple: stringListPtr;               {pointer to the last element in parameterList}
       pnum: integer;                    {for counting parameters}
       tPtr,tk1,tk2: tokenListRecordPtr; {pointer to a token}
+      luseGlobalPool: boolean;          {local copy of useGlobalPool}
 
    begin {DoDefine}
+
+   lUseGlobalPool := useGlobalPool;
+   useGlobalPool := true;               {use global memory for defines}
    expandMacros := false;               {block expansions}
    saveNumber := true;                  {save characters in numeric tokens}
    parameterList := nil;                {no parameters yet}
@@ -2999,6 +3003,7 @@ var
       dispose(np);
       end; {while}
    saveNumber := false;                 {stop saving numeric strings}
+   useGlobalPool := lUseGlobalPool;
    end; {DoDefine}
 
 


### PR DESCRIPTION
if a `#define` is within a function, it will use the local memory pool for string allocation -- via Malloc in NextToken - https://github.com/byteworksinc/ORCA-C/blob/25085f5b813299a0ca7003f77d8cbf318dc139e7/Scanner.pas#L5780

which can lead to a dangling memory reference when the macro is expanded.

example:
```
void function(void) {

#define TEXT "abc"

static struct {
	char text[sizeof(TEXT)];
} template = { TEXT };

}
```